### PR TITLE
Base CentOS 6 and 7 and RHEL 7 boxes are useful for testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ this Vagrant configuration accessible through a web browser, or SSH
 
     192.168.33.55 omar-single.rbtcloud.dev
     192.168.33.56 elk.rbtcloud.dev
-    192.168.33.57 base.rbtcloud.dev
+    192.168.33.57 base6.rbtcloud.dev
     192.168.33.58 ossim-single.rbtcloud.dev
     192.168.33.59 geowave-single.rbtcloud.dev
     192.168.33.60 pgsql-single.rbtcloud.dev
+    192.168.33.61 base7.rbtcloud.dev
+    192.168.33.61 rhel7.rbtcloud.dev
 
 ### OSSIM Only Without Access to sm-rbtcloud
 The `sm-rbtcloud` repo contains proprietary company specific credentials and
@@ -102,3 +104,7 @@ and be up and running quickly:
 OSSIM.
 2. `$ vagrant up ossim` will install the dependencies you need as well as OSSIM itself.
 
+### The RedHat Box
+To do any software installation or yum activities, you'll need a free RedHat
+Developer license. You can get it from [developer.redhat.com](https://github.com/projectatomic/adb-vagrant-registration). After that, you can use the [vagrant-registration](https://github.com/projectatomic/adb-vagrant-registration) plugin to register and automatically de-register
+your vagrant box. 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,10 +29,10 @@ Vagrant.configure(2) do |config|
   end
 
   # A clean slate CentOS 6 Machine for experimenting and testing
-  config.vm.define "base", autostart: false do |base|
-    base.vm.box = "bhosmer/centos6.6-minimal" 
-    base.vm.hostname = "base.rbtcloud.dev"
-    base.vm.network "private_network", ip: "192.168.33.57"
+  config.vm.define "base6", autostart: false do |base6|
+    base6.vm.box = "bhosmer/centos6.6-minimal" 
+    base6.vm.hostname = "base6.rbtcloud.dev"
+    base6.vm.network "private_network", ip: "192.168.33.57"
   end
   
   # A clean slate CentOS 6 Machine for experimenting and testing
@@ -65,6 +65,26 @@ Vagrant.configure(2) do |config|
       salt.run_highstate = true
       salt.log_level = "all"
     end
+  end
+
+  # A clean slate CentOS 7 Machine for experimenting and testing
+  config.vm.define "base7", autostart: false do |base7|
+    base7.vm.box = "bhosmer/centos7-minimal" 
+    base7.vm.hostname = "base7.rbtcloud.dev"
+    base7.vm.network "private_network", ip: "192.168.33.61"
+  end
+
+  # A clean RHEL 7 Machine for experimenting and testing
+  # To do any yum activities, you need a free RedHat Developer subscription
+  # See http://developers.redhat.com/products/rhel/get-started/
+  config.vm.define "rhel7", autostart: false do |rhel7|
+    if Vagrant.has_plugin?('vagrant-registration')
+      config.registration.username = 'YOURREDHATUSERNAME'
+      config.registration.password = 'YOURREDHATPASSWORD'
+    end
+    rhel7.vm.box = "https://s3-us-west-2.amazonaws.com/otd-vagrant-boxes/rhel7-minimal.box"
+    rhel7.vm.hostname = "rhel7.rbtcloud.dev"
+    rhel7.vm.network "private_network", ip: "192.168.33.62"
   end
  
   config.vm.synced_folder ".", "/vagrant", type: "nfs"


### PR DESCRIPTION
This adds support and fixes https://github.com/radiantbluetechnologies/sm-rbtcloud-com/issues/275 for a basic CentOS 6, 7 and a RedHat 7 Vagrant box. It includes new ip and hostname settings in the README.